### PR TITLE
Add missing SASS definitions

### DIFF
--- a/resources/sass/_definitions.scss
+++ b/resources/sass/_definitions.scss
@@ -1,0 +1,1 @@
+@import '../../../../../themes/custom/iq_barrio/resources/sass/definitions';

--- a/resources/sass/libsass.ini
+++ b/resources/sass/libsass.ini
@@ -1,0 +1,1 @@
+css_dir = '../../resources/css'


### PR DESCRIPTION
* The references SASS definition in the `teaser` pattern doesn't exist ([see here](https://github.com/iqual-ch/iq_events/blob/8.x-1.x/patterns/iq-event-teaser/teaser.scss#L1))
* This breaks the SASS compilation
* A proper definition that references the theme definition is needed along with a `libsass.ini`